### PR TITLE
moved credentials in configuration node, fixed crash if fritzbox is not available as fritz.box

### DIFF
--- a/fritz.js
+++ b/fritz.js
@@ -1,9 +1,7 @@
 const http = require('http')
 
-
 module.exports.checkSession = function(sid, callback, options) {
     options || (options = {})
-    options.host || (options.host = 'fritz.box')
     options.path || (options.path = '/login_sid.lua')
     options.path += '?sid=' + sid
     try {
@@ -21,13 +19,11 @@ module.exports.checkSession = function(sid, callback, options) {
     }
 }
 
-
 module.exports.getSessionID = function(username, password, callback, options) {
     if (typeof username != 'string') throw new Error('Invalid username')
     if (typeof password != 'string') throw new Error('Invalid password')
 
     options || (options = {})
-    options.host || (options.host = 'fritz.box')
     options.path || (options.path = '/login_sid.lua')
 
     var sessionID = ""
@@ -56,7 +52,6 @@ module.exports.getSessionID = function(username, password, callback, options) {
         throw new Error('Error getting Session ID from FritzBox. Please check configuration.')
     }
 }
-
 
 module.exports.getData = function(sid, callback, options) {
     options || (options = {})

--- a/fritzbox-presence-credentials.html
+++ b/fritzbox-presence-credentials.html
@@ -1,0 +1,28 @@
+<script type="text/javascript">
+    RED.nodes.registerType('fritzbox-presence-credentials',{
+        category: 'config',
+        defaults: {
+          username: { value: '', required: true },
+          password: { value: '', required: true },
+          hostname: { value: 'fritz.box', required: true }
+        },
+        label: function() {
+          return this.hostname;
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="fritzbox-presence-credentials">
+    <div class="form-row">
+        <label for="node-config-input-hostname"><i class="icon-tag"></i> Hostname</label>
+        <input type="text" id="node-config-input-hostname">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-username"><i class="icon-tag"></i> Username</label>
+        <input type="text" id="node-config-input-username">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-password"><i class="icon-tag"></i> Password</label>
+        <input type="password" id="node-config-input-password">
+    </div>
+</script>

--- a/fritzbox-presence-credentials.js
+++ b/fritzbox-presence-credentials.js
@@ -1,0 +1,13 @@
+module.exports = function (RED) {
+  function FritzBoxPresenceCredentialNode (config) {
+    RED.nodes.createNode(this, config)
+    this.hostname = config.hostname
+    this.username = config.username
+    this.password = config.password
+  }
+
+  RED.nodes.registerType(
+    'fritzbox-presence-credentials',
+    FritzBoxPresenceCredentialNode
+  )
+}

--- a/fritzbox-presence.html
+++ b/fritzbox-presence.html
@@ -3,22 +3,7 @@
         category: 'fritzbox',
         color: '#d08181',
         defaults: {
-            name: {
-                value: "",
-                required: false
-            },
-            host: {
-                value: "fritz.box",
-                required: true
-            }
-        },
-        credentials: {
-            username: {
-                type: "text"
-            },
-            password: {
-                type: "password"
-            }
+          fritz: { type:'fritzbox-presence-credentials', required: true },
         },
         inputs: 1,
         outputs: 1,
@@ -31,20 +16,16 @@
 
 <script type="text/x-red" data-template-name="fritzbox-presence">
     <div class="form-row">
+      <label for="node-input-fritz">Fritz</label>
+      <input id="node-input-fritz"></input>
+    </div>
+    <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-host"><i class="fa fa-keyboard-o"></i>Host</label>
+        <label for="node-input-host"><i class="fa fa-keyboard-o"></i> Host</label>
         <input type="text" id="node-input-host" placeholder="fritz.box">
-    </div>
-    <div class="form-row">
-        <label for="node-input-username"><i class="icon-tag"></i> Username</label>
-        <input type="text" id="node-input-username">
-    </div>
-    <div class="form-row">
-        <label for="node-input-password"><i class="icon-tag"></i> Password</label>
-        <input type="password" id="node-input-password">
     </div>
 </script>
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "bugs": "https://github.com/felixfischer/node-red-contrib-fritzbox-presence/issues",
   "node-red": {
     "nodes": {
-      "fritzbox-presence": "fritzbox-presence.js"
+      "fritzbox-presence": "fritzbox-presence.js",
+      "fritzbox-presence-credentials": "fritzbox-presence-credentials.js"
     }
   }
 }


### PR DESCRIPTION
Hi,

I was very happy about your node-red node. Sadly it crashes on my side because my fritzbox is not available under fritz.box, which is currently the only way to use your node.

So I fixed this. Default is still fritz.box, but can be overwritten now.

My second change was to move the credentials in a regular configuration node 